### PR TITLE
uses lambda so that initializers work

### DIFF
--- a/app/models/blog_entry.rb
+++ b/app/models/blog_entry.rb
@@ -5,7 +5,7 @@ class BlogEntry < ActiveRecord::Base
   before_save :create_permalink
   validates_presence_of :title
 
-  default_scope order("created_at DESC")
+  default_scope lambda { order("created_at DESC") }
   scope :published, lambda { where("blog_entries.created_at <= ?", Time.zone.now) }
   scope :latest, lambda { |n| published.limit(n.to_i) }
 


### PR DESCRIPTION
Using lambdas or procs makes sure that the code is run only when needed (btw I think this is required for Rails versions greater than 4).
